### PR TITLE
Add parse.sh, update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 
 # mac
 .DS_Store
+
+# vscode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ pip3 install open_parser
 ```
 
 ## :bashfile usage
+To use OpenParse via `curl` requests, you can run the following bash command from the root folder of this repository:
+```
+bash parse.sh <your apiKey> <file path> <prompt for parse (optional, default="")>
+```
 
+For example, to extract a table from a PDF file, you can run the following command:
 ```
-bash open_parser.sh <your apiKey> <job type: extract | parse> <file path> <prompt for parse (optional, default="")> <parse mode (optional, default=basic): basic | advanced>
+bash parse.sh gl**************************************  /path/to/your/file.pdf "Return the table in a JSON format with
+ each box's key and value."
 ```
+
 ## :scroll:  Examples
 
 OpenParse can extract text, numbers and symbols from PDF, images, etc. Check out each notebook below to run OpenParse within 10 lines of code!

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ bash parse.sh <your apiKey> <file path> <prompt for parse (optional, default="")
 
 For example, to extract a table from a PDF file, you can run the following command:
 ```
-bash parse.sh gl**************************************  /path/to/your/file.pdf "Return the table in a JSON format with
- each box's key and value."
+bash parse.sh gl**************************************  /path/to/your/file.pdf "Return the table in a JSON format with each box's key and value."
 ```
 
 ## :scroll:  Examples

--- a/extract_parse.sh
+++ b/extract_parse.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+source open_parser_base.sh
+
+if [ "$#" -lt 3 ]; then
+    echo "Error: Missing arguments
+    Usage: $0 <api_key> <job type: extract | parse> <file path> <prompt for parse (optional, default="")> <parse mode (optional, default=basic): basic | advanced>"
+    exit 1
+fi
+
+apiKey="$1"
+func="$2"
+file_path="$3"
+
+upload
+if [ "$func" == "extract" ]; then
+    extract
+elif [ "$func" == "parse" ]; then
+    prompt="$4"
+    mode="$5"
+    if [ -z "$mode" ] || [ "$mode" == "" ] || [ "$mode" == "advanced" ]; then
+        textract=true
+    else
+        textract=false
+    fi
+    upload
+    parse
+fi
+
+echo "$result"

--- a/open_parser_base.sh
+++ b/open_parser_base.sh
@@ -1,5 +1,5 @@
-UPLOAD_URL="https://qreije6m7l.execute-api.us-west-2.amazonaws.com/v1/cambio_api/upload"  
-EXTRACT_URL="https://qreije6m7l.execute-api.us-west-2.amazonaws.com/v1/cambio_api/extract" 
+UPLOAD_URL="https://qreije6m7l.execute-api.us-west-2.amazonaws.com/v1/cambio_api/upload"
+EXTRACT_URL="https://qreije6m7l.execute-api.us-west-2.amazonaws.com/v1/cambio_api/extract"
 PARSE_URL="https://qreije6m7l.execute-api.us-west-2.amazonaws.com/v1/cambio_api/parse"
 
 uid="null"
@@ -30,13 +30,6 @@ upload() {
         exit 1
     fi
 
-    # res=$(echo "$tmp_data" | jq -r 'to_entries | map("-F \"\(.key)=\(.value)\" \\ ") | .[] ')    
-    # echo "${res[@]}"
-    # local status=$(curl -X POST \
-    #     "${res[@]}" \
-    #     -F "file=@$file_path" \
-    #     "$tmp_url")
-
     local aws_access_key_id=$(echo "$tmp_data" | jq -r '."AWSAccessKeyId"')
     local x_amz_security_token=$(echo "$tmp_data" | jq -r '."x-amz-security-token"')
     local policy=$(echo "$tmp_data" | jq -r '."policy"')
@@ -60,8 +53,6 @@ upload() {
         -F "x-amz-meta-user_prompt=$x_amz_meta_user_prompt" \
         -F "file=@$file_path" \
         "$tmp_url")
-    
-    # echo "upload done"
 }
 
 extract() {
@@ -76,7 +67,6 @@ extract() {
                     -d "$payload" \
                     "$EXTRACT_URL")
 
-    # echo "$response" 
     result=$(echo "$response" | jq -r '.result.file_content')
 }
 
@@ -94,28 +84,5 @@ parse() {
                     -d "$payload" \
                     "$PARSE_URL")
 
-    # echo "$response" 
     result=$(echo "$response" | jq -r '.result')
 }
-
-
-apiKey="$1"
-func="$2"
-file_path="$3"
-
-upload
-if [ "$func" == "extract" ]; then
-    extract
-elif [ "$func" == "parse" ]; then
-    prompt="$4"
-    mode="$5"
-    if [ -z "$mode" ] || [ "$mode" == "" ] || [ "$mode" == "advanced" ]; then
-        textract=true
-    else
-        textract=false
-    fi
-    upload
-    parse
-fi
-
-echo "$result"

--- a/parse.sh
+++ b/parse.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 source open_parser_base.sh
 
-# Check if number of arguments is not equal to 3
 if [ "$#" -lt 2 ]; then
     echo "Error: Missing arguments
     Usage: $0 <apiKey> <file_path> <prompt (optional, default="")>"

--- a/parse.sh
+++ b/parse.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+source open_parser_base.sh
+
+# Check if number of arguments is not equal to 3
+if [ "$#" -lt 2 ]; then
+    echo "Error: Missing arguments
+    Usage: $0 <apiKey> <file_path> <prompt (optional, default="")>"
+    exit 1
+fi
+
+apiKey="$1"
+file_path="$2"
+prompt="$3"
+textract=false
+
+echo "Parsing $file_path..."
+
+upload
+parse
+
+echo "$result"


### PR DESCRIPTION
- add `parse.sh` to run a parse in basic mode by default
- move common methods/vars to `open_parser_base.sh`
- rename `open_parser.sh` -> `extract_parse.sh`
- Update README with `parse` bash example